### PR TITLE
fix(ui): align macro report scores with 0–100 scale (#33)

### DIFF
--- a/app/components/ScoreRangeBar.tsx
+++ b/app/components/ScoreRangeBar.tsx
@@ -6,12 +6,15 @@ export function ScoreRangeBar({
   note,
   max = 100,
   className,
+  /** When there is no label row, place the note above or below the bar. */
+  notePlacement = "above",
 }: {
   label?: string;
   value: number | null | undefined;
   note?: string;
   max?: number;
   className?: string;
+  notePlacement?: "above" | "below";
 }) {
   const upper = Math.max(0.000001, max);
   const v = typeof value === "number" && Number.isFinite(value) ? value : 0;
@@ -33,7 +36,7 @@ export function ScoreRangeBar({
           </div>
         </div>
       )}
-      {!showLabelRow && note && (
+      {!showLabelRow && note && notePlacement === "above" && (
         <div className="text-sm text-foreground whitespace-nowrap text-right">
           {note}
         </div>
@@ -46,6 +49,12 @@ export function ScoreRangeBar({
           aria-hidden="true"
         />
       </div>
+
+      {!showLabelRow && note && notePlacement === "below" && (
+        <div className="text-sm text-foreground whitespace-nowrap text-right">
+          {note}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/components/ScoreRangeBar.tsx
+++ b/app/components/ScoreRangeBar.tsx
@@ -1,0 +1,51 @@
+import { cn } from "@/app/lib/utils";
+
+export function ScoreRangeBar({
+  label,
+  value,
+  note,
+  max = 100,
+  className,
+}: {
+  label?: string;
+  value: number | null | undefined;
+  note?: string;
+  max?: number;
+  className?: string;
+}) {
+  const upper = Math.max(0.000001, max);
+  const v = typeof value === "number" && Number.isFinite(value) ? value : 0;
+  const clamped = Math.max(0, Math.min(upper, v));
+  const widthPct = (clamped / upper) * 100;
+
+  const showLabelRow =
+    label !== undefined && label !== null && label.trim() !== "";
+
+  return (
+    <div className={cn("space-y-1", className)}>
+      {showLabelRow && (
+        <div className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-3">
+          <div className="text-sm font-semibold text-foreground whitespace-nowrap">
+            {label}
+          </div>
+          <div className="text-sm text-foreground whitespace-nowrap">
+            {note ?? "—"}
+          </div>
+        </div>
+      )}
+      {!showLabelRow && note && (
+        <div className="text-sm text-foreground whitespace-nowrap text-right">
+          {note}
+        </div>
+      )}
+
+      <div className="relative h-2 rounded-full bg-gray-500 overflow-hidden">
+        <div
+          className="absolute inset-y-0 left-0 rounded-full bg-linear-to-r from-pink-400 via-fuchsia-400 to-violet-400"
+          style={{ width: `${widthPct}%` }}
+          aria-hidden="true"
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/components/macro/MacroReportRenderer.tsx
+++ b/app/components/macro/MacroReportRenderer.tsx
@@ -166,11 +166,15 @@ export function MacroReportRenderer({
   const verdictTitle = verdict?.title ?? "—";
   const baseNote =
     typeof baseScore === "number"
-      ? `${baseScore >= 0 ? "+" : ""}${baseScore.toFixed(2)} (BS) • ${verdictTitle}`
+      ? `${baseScore.toFixed(2)} / 100 • ${verdictTitle}`
       : "—";
   const adjNote =
     typeof qualitativeAdjustment === "number"
-      ? `${qualitativeAdjustment >= 0 ? "+" : ""}${qualitativeAdjustment.toFixed(2)} (QA)`
+      ? `${qualitativeAdjustment >= 0 ? "+" : ""}${qualitativeAdjustment.toFixed(2)} points • cap +/- 25`
+      : "—";
+  const effectiveNote =
+    typeof effectiveScore === "number"
+      ? `${effectiveScore.toFixed(2)} / 100`
       : "—";
 
   return (
@@ -195,6 +199,7 @@ export function MacroReportRenderer({
                 }
                 baseNote={baseNote}
                 adjNote={adjNote}
+                effectiveNote={effectiveNote}
                 verdictTitle={verdictTitle}
                 macroCadence={macroCadence}
                 onMacroCadenceChange={onMacroCadenceChange}

--- a/app/components/macro/MacroReportRenderer.tsx
+++ b/app/components/macro/MacroReportRenderer.tsx
@@ -8,6 +8,7 @@ import { MacroReportHeaderCard } from "@/app/components/report/MacroReportHeader
 import {
   extractMacroRegimeDetails,
   extractMacroRegimeLabel,
+  formatMacroScoreBreakdown,
   getMacroVerdict,
   macroRegimeImageSrc,
 } from "@/app/lib/macro-economics";
@@ -172,10 +173,16 @@ export function MacroReportRenderer({
     typeof qualitativeAdjustment === "number"
       ? `${qualitativeAdjustment >= 0 ? "+" : ""}${qualitativeAdjustment.toFixed(2)} points • cap +/- 25`
       : "—";
+  const scoreBreakdown = formatMacroScoreBreakdown({
+    baseScore,
+    qualitativeAdjustment,
+    effectiveScore,
+  });
   const effectiveNote =
-    typeof effectiveScore === "number"
+    scoreBreakdown ??
+    (typeof effectiveScore === "number"
       ? `${effectiveScore.toFixed(2)} / 100`
-      : "—";
+      : "—");
 
   return (
     <div className="w-full max-w-4xl mx-auto space-y-4">

--- a/app/components/report/MacroReportHeaderCard.tsx
+++ b/app/components/report/MacroReportHeaderCard.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { ChevronLeft, ChevronRight, ExternalLink } from "lucide-react";
+import { ScoreRangeBar } from "@/app/components/ScoreRangeBar";
 import { SignedRangeBar } from "@/app/components/SignedRangeBar";
 import { cn, imageUrl } from "@/app/lib/utils";
 import { formatTimestamp } from "@/app/lib/format";
@@ -14,6 +15,8 @@ export function MacroReportHeaderCard(props: {
   qualitativeAdjustment: number | null;
   baseNote: string;
   adjNote: string;
+  /** Shown under the effective score bar (e.g. "60.00 / 100"). */
+  effectiveNote?: string;
   verdictTitle: string;
   macroCadence?: "daily" | "weekly";
   onMacroCadenceChange?: (cadence: "daily" | "weekly") => void;
@@ -34,6 +37,7 @@ export function MacroReportHeaderCard(props: {
     qualitativeAdjustment,
     adjNote,
     effectiveScore,
+    effectiveNote,
     verdictTitle,
     executedAt,
     variantCode,
@@ -234,26 +238,25 @@ export function MacroReportHeaderCard(props: {
               </div>
 
               <div className="space-y-4">
-                <SignedRangeBar
+                <ScoreRangeBar
                   label="Base Score"
                   value={baseScore}
                   note={baseNote}
-                  maxAbs={1}
                 />
                 <SignedRangeBar
                   label="Qualitative Adjustment"
                   value={qualitativeAdjustment}
                   note={adjNote}
-                  maxAbs={1}
+                  maxAbs={25}
                 />
                 <div className="rounded-lg border border-pink-400/30 bg-pink-400/5 p-3 space-y-2 mb-3 md:mb-0">
-                  <div className="flex items-baseline justify-between gap-3">
+                  <div className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-3">
                     <div className="text-sm font-semibold text-foreground whitespace-nowrap">
                       Effective Score
                     </div>
                     <div className="text-sm font-semibold text-foreground flex flex-wrap items-center gap-1.5">
                       {typeof effectiveScore === "number"
-                        ? `${effectiveScore.toFixed(2)} (ES)`
+                        ? `${effectiveScore.toFixed(2)} / 100`
                         : "—"}
                       {typeof effectiveScore === "number" && (
                         <>
@@ -268,10 +271,10 @@ export function MacroReportHeaderCard(props: {
                       )}
                     </div>
                   </div>
-                  <SignedRangeBar
+                  <ScoreRangeBar
                     label=""
                     value={effectiveScore}
-                    maxAbs={1}
+                    note={effectiveNote}
                     className="!space-y-0"
                   />
                 </div>

--- a/app/components/report/MacroReportHeaderCard.tsx
+++ b/app/components/report/MacroReportHeaderCard.tsx
@@ -255,12 +255,8 @@ export function MacroReportHeaderCard(props: {
                       Effective Score
                     </div>
                     <div className="text-sm font-semibold text-foreground flex flex-wrap items-center gap-1.5">
-                      {typeof effectiveScore === "number"
-                        ? `${effectiveScore.toFixed(2)} / 100`
-                        : "—"}
-                      {typeof effectiveScore === "number" && (
+                      {typeof effectiveScore === "number" ? (
                         <>
-                          <span className="text-muted-foreground">•</span>
                           <span className="inline-flex items-center rounded-md border border-pink-400/60 bg-pink-400/15 px-2 py-0.5 font-mono text-[11px] text-foreground whitespace-nowrap">
                             {regimeLabel ?? "—"}
                           </span>
@@ -268,14 +264,20 @@ export function MacroReportHeaderCard(props: {
                             {verdictTitle}
                           </span>
                         </>
+                      ) : (
+                        "—"
                       )}
                     </div>
                   </div>
                   <ScoreRangeBar
                     label=""
                     value={effectiveScore}
-                    note={effectiveNote}
-                    className="!space-y-0"
+                    note={
+                      typeof effectiveScore === "number"
+                        ? effectiveNote
+                        : undefined
+                    }
+                    notePlacement="below"
                   />
                 </div>
               </div>

--- a/app/lib/macro-economics.test.ts
+++ b/app/lib/macro-economics.test.ts
@@ -3,6 +3,7 @@ import type { LensOutputArtifact } from "@/app/lib/report-types";
 import {
   extractMacroRegimeDetails,
   extractMacroRegimeLabel,
+  formatMacroScoreBreakdown,
   getMacroVerdict,
 } from "@/app/lib/macro-economics";
 
@@ -37,6 +38,21 @@ describe("macro-economics", () => {
       };
       expect(extractMacroRegimeLabel(artifact)).toBe("R-");
     });
+
+    it("parses **Effective Regime** row", () => {
+      const artifact: LensOutputArtifact = {
+        kind: "markdown",
+        artifact_type: "report",
+        content: {
+          header:
+            "| **Effective Regime** | R+ — Risk On |\n|---|---|",
+          body: "",
+          footer: "",
+        },
+        content_type: "text/markdown",
+      };
+      expect(extractMacroRegimeLabel(artifact)).toBe("R+");
+    });
   });
 
   describe("extractMacroRegimeDetails", () => {
@@ -47,17 +63,17 @@ describe("macro-economics", () => {
         content: {},
         content_type: "application/json",
         meta: {
-          macro_effective_score: 8,
-          macro_base_score: 10,
-          macro_qualitative_adjustment: -2,
+          macro_effective_score: 60,
+          macro_base_score: 72,
+          macro_qualitative_adjustment: -12,
         },
       };
       expect(extractMacroRegimeDetails(artifact)).toEqual({
-        score: 8,
+        score: 60,
         coveragePct: null,
-        effectiveScore: 8,
-        baseScore: 10,
-        qualitativeAdjustment: -2,
+        effectiveScore: 60,
+        baseScore: 72,
+        qualitativeAdjustment: -12,
       });
     });
 
@@ -69,7 +85,7 @@ describe("macro-economics", () => {
           header: [
             "# Some Title",
             "",
-            "| **Score** | 10 (BS) - 2 (QA) = 8 (ES) |",
+            "| **Score** | 72.00 (BS) - 12.00 (QA) = 60.00 (ES) |",
             "|---|---|",
           ].join("\n"),
           body: "",
@@ -79,10 +95,22 @@ describe("macro-economics", () => {
       };
 
       const details = extractMacroRegimeDetails(artifact);
-      expect(details.score).toBe(8);
-      expect(details.baseScore).toBe(10);
-      expect(details.qualitativeAdjustment).toBe(-2);
-      expect(details.effectiveScore).toBe(8);
+      expect(details.score).toBe(60);
+      expect(details.baseScore).toBe(72);
+      expect(details.qualitativeAdjustment).toBe(-12);
+      expect(details.effectiveScore).toBe(60);
+    });
+  });
+
+  describe("formatMacroScoreBreakdown", () => {
+    it("formats the macro score breakdown on the 0-100 scale", () => {
+      expect(
+        formatMacroScoreBreakdown({
+          baseScore: 72,
+          qualitativeAdjustment: -12,
+          effectiveScore: 60,
+        })
+      ).toBe("72.00 (BS) - 12.00 (QA) = 60.00 (ES)");
     });
   });
 

--- a/app/lib/macro-economics.test.ts
+++ b/app/lib/macro-economics.test.ts
@@ -44,8 +44,7 @@ describe("macro-economics", () => {
         kind: "markdown",
         artifact_type: "report",
         content: {
-          header:
-            "| **Effective Regime** | R+ — Risk On |\n|---|---|",
+          header: "| **Effective Regime** | R+ — Risk On |\n|---|---|",
           body: "",
           footer: "",
         },

--- a/app/lib/macro-economics.ts
+++ b/app/lib/macro-economics.ts
@@ -3,6 +3,24 @@ import { imageUrl } from "./utils";
 
 export type MacroRegimeLabel = "R++" | "R+" | "N" | "R-" | "D";
 
+export function formatMacroScoreBreakdown(args: {
+  baseScore: number | null | undefined;
+  qualitativeAdjustment: number | null | undefined;
+  effectiveScore: number | null | undefined;
+}): string | null {
+  const { baseScore, qualitativeAdjustment, effectiveScore } = args;
+  if (
+    typeof baseScore !== "number" ||
+    typeof qualitativeAdjustment !== "number" ||
+    typeof effectiveScore !== "number"
+  )
+    return null;
+
+  const op = qualitativeAdjustment >= 0 ? "+" : "-";
+  const absAdj = Math.abs(qualitativeAdjustment);
+  return `${baseScore.toFixed(2)} (BS) ${op} ${absAdj.toFixed(2)} (QA) = ${effectiveScore.toFixed(2)} (ES)`;
+}
+
 export function extractMacroRegimeLabel(
   artifact: LensOutputArtifact | null | undefined
 ): MacroRegimeLabel | null {
@@ -30,7 +48,9 @@ export function extractMacroRegimeLabel(
   ) {
     const header = (content as { header?: unknown }).header;
     if (typeof header === "string" && header) {
-      const m = header.match(/\|\s*\*\*Regime\*\*\s*\|\s*([^|]+)\|/i);
+      const m = header.match(
+        /\|\s*\*\*(?:Effective\s+)?Regime\*\*\s*\|\s*([^|]+)\|/i
+      );
       const raw = (m?.[1] || "").trim();
       const label = raw.split(/\s+/)[0]?.trim() || "";
       if (label === "R+" || label === "N" || label === "R-") return label;
@@ -85,6 +105,7 @@ export function extractMacroRegimeDetails(
   ) {
     const header = (content as { header?: unknown }).header;
     if (typeof header === "string" && header) {
+      // e.g. 72.00 (BS) - 12.00 (QA) = 60.00 (ES) on the 0–100 scale
       const scoreRow = header.match(/\|\s*\*\*Score\*\*\s*\|\s*([^|]+)\|/i);
       const scoreText = (scoreRow?.[1] || "").trim();
       const m = scoreText.match(


### PR DESCRIPTION
## Context & Purpose

Macro report scores from the Messy Virgo pipeline are published on a **0–100** scale. The Base mini app still rendered them with **signed ±1** range bars and old-style labels, which misrepresented values and drifted from the main `messyvirgo-platform` UI. This change aligns presentation and copy with the platform implementation documented in **#33**.

## Implementation & Design

- Added **`ScoreRangeBar`**: single-sided 0–100 (default max) fill, styled consistently with existing macro gradients.
- **`MacroReportHeaderCard`**: base and effective scores use `ScoreRangeBar`; qualitative adjustment stays on **`SignedRangeBar`** with **`maxAbs={25}`**; effective headline uses **`x.xx / 100`**; optional **`effectiveNote`** under the effective bar.
- **`MacroReportRenderer`**: notes match platform (`/ 100`, `points • cap +/- 25`).
- **`macro-economics`**: `formatMacroScoreBreakdown` helper; regime header regex accepts **`**Effective Regime**`** as well as **`**Regime**`**; tests updated for 0–100 examples.

## Impact on MVP/Product Strategy

Users see scores that match the published report semantics and the main Messy Virgo web app, reducing confusion when comparing the Base mini app to other surfaces.

## How to Review/Test

- Open the app with a daily macro report that includes score meta or header row `Score | … (BS) … (QA) = … (ES) |`.
- Confirm base and effective bars fill left-to-right 0–100; QA bar is centered with ±25 cap; copy shows `/ 100` and QA cap text.
- Run: `npm test -- --run` and `npm run typecheck`.

## Key Decisions & Tradeoffs

- **Parity over novelty**: mirrored `LensAnalysisResults` / `MacroReportHeaderCard` from `messyvirgo-platform` rather than inventing a new scale visualization.
- **No API change**: extraction regex already supported 0–100 header strings; meta fields unchanged.

## Investor Notes

N/A — correctness and UX consistency for an existing educational surface.

## Checklist

- [x] Code runs locally
- [x] Core business logic/feature covered
- [x] No major bugs found in manual smoke tests
- [ ] PR linked to project milestone or investor KPI

## Screenshots/Reference (optional)

See issue **#33** for backwards-engineering context and problem statement.

## Next Steps (optional)

None required; optional follow-up if download/PDF views duplicate score formatting elsewhere.

---

Closes #33

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes plus small string/regex formatting helpers; low risk aside from potential edge cases in header parsing/score display.
> 
> **Overview**
> Aligns the macro report header’s score presentation to a **0–100 scale** by introducing a new one-sided `ScoreRangeBar` and switching the Base and Effective score visuals away from the previous signed +/- range.
> 
> Updates macro header copy/notes to match the new scale (`x.xx / 100`, QA shown as `points • cap +/- 25`), adds `formatMacroScoreBreakdown` to produce an `BS +/- QA = ES` note for the effective score, and broadens regime parsing to accept `**Effective Regime**` rows; tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2411583748bf0e645df0d8afd2a3a54c522a908b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->