### PR TITLE
fix(api): use Messy Virgo public macro report routes

### DIFF
--- a/app/api/macro/messyVirgoApiClient.test.ts
+++ b/app/api/macro/messyVirgoApiClient.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getLatestDailyMacroReport,
+  getLatestDailyMacroTwitterPostText,
+} from "@/lib/messyVirgoApiClient";
+
+const reportResponse = {
+  outputs: [],
+  meta: { published_at: "2026-02-05T12:34:56.000Z", is_stale: false },
+};
+
+describe("Messy Virgo upstream API client", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches macro reports from the canonical public route", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      Response.json(reportResponse)
+    );
+
+    await getLatestDailyMacroReport("base_app");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.messyvirgo.com/api/v1/public/reports/macro/report/base_app",
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+
+  it("fetches macro twitter posts from the canonical public route", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      Response.json({
+        outputs: [
+          {
+            content: { text: "macro share text" },
+          },
+        ],
+        meta: reportResponse.meta,
+      })
+    );
+
+    await getLatestDailyMacroTwitterPostText("base_app");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.messyvirgo.com/api/v1/public/reports/macro/twitter_post/base_app",
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+});

--- a/lib/messyVirgoApiClient.ts
+++ b/lib/messyVirgoApiClient.ts
@@ -23,7 +23,7 @@ function resolveDailyMacroPath(variantCode: string): string {
       ? variantCode.trim()
       : DEFAULT_DAILY_MACRO_REPORT_VARIANT_CODE;
   // Variant codes are a single path segment in the upstream API.
-  return `/api/v1/published/macro/report/${encodeURIComponent(normalized)}`;
+  return `/api/v1/public/reports/macro/report/${encodeURIComponent(normalized)}`;
 }
 
 function resolveDailyMacroTwitterPostPath(variantCode: string): string {
@@ -32,7 +32,7 @@ function resolveDailyMacroTwitterPostPath(variantCode: string): string {
       ? variantCode.trim()
       : DEFAULT_DAILY_MACRO_REPORT_VARIANT_CODE;
   // Variant codes are a single path segment in the upstream API.
-  return `/api/v1/published/macro/twitter_post/${encodeURIComponent(normalized)}`;
+  return `/api/v1/public/reports/macro/twitter_post/${encodeURIComponent(normalized)}`;
 }
 
 function buildAuthHeaders(): Record<string, string> {


### PR DESCRIPTION
## Summary

The Messy Virgo upstream client now calls the **public** macro endpoints (`/api/v1/public/reports/macro/report/...` and `.../twitter_post/...`) instead of the previous `/api/v1/published/macro/...` paths, matching the current Messy Virgo platform API.

Vitest coverage asserts the exact URLs used for daily macro reports and Twitter post text so future path changes are caught early.

## Test plan

- [ ] `pnpm test` / `vitest` (includes `app/api/macro/messyVirgoApiClient.test.ts`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the upstream URLs used to fetch macro reports and twitter post text, which can affect production data retrieval if the new routes differ or are misconfigured. Added tests reduce regression risk by pinning the expected canonical URLs.
> 
> **Overview**
> Updates the Messy Virgo API client to call the **public** macro report endpoints (switching from `/api/v1/published/macro/...` to `/api/v1/public/reports/macro/...`) for both the daily report and `twitter_post` text.
> 
> Adds a Vitest suite that mocks `fetch` and asserts the exact request URLs used, so future endpoint/path regressions are caught early.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e41ec2a902e2f4184418bebe4311cbc89e82a5c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->