### PR TITLE
Remove report profile variants

### DIFF
--- a/app/api/macro/_shared.test.ts
+++ b/app/api/macro/_shared.test.ts
@@ -2,25 +2,44 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createBoundedTtlCache,
   getCachedMacroReport,
-  parseVariant,
+  parseReportKind,
   sanitizeDownloadFilename,
 } from "@/app/api/macro/_shared";
 
-describe("parseVariant", () => {
-  it("defaults when missing", () => {
+describe("parseReportKind", () => {
+  it("defaults to the daily dashboard when missing", () => {
     const request = new Request("https://example.com/api/macro/latest");
-    const parsed = parseVariant(request);
+    const parsed = parseReportKind(request);
     expect(parsed.ok).toBe(true);
     if (parsed.ok) {
-      expect(parsed.variant).toBeTruthy();
+      expect(parsed.reportKind).toBe("daily");
     }
   });
 
-  it("rejects invalid variant", () => {
+  it("accepts the full report", () => {
     const request = new Request(
-      "https://example.com/api/macro/latest?variant=bad%0Avalue"
+      "https://example.com/api/macro/latest?report=default"
     );
-    const parsed = parseVariant(request);
+    const parsed = parseReportKind(request);
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) {
+      expect(parsed.reportKind).toBe("default");
+    }
+  });
+
+  it("rejects unsupported report kinds", () => {
+    const request = new Request(
+      "https://example.com/api/macro/latest?report=base_app"
+    );
+    const parsed = parseReportKind(request);
+    expect(parsed.ok).toBe(false);
+  });
+
+  it("rejects stale variant query parameters", () => {
+    const request = new Request(
+      "https://example.com/api/macro/latest?variant=default"
+    );
+    const parsed = parseReportKind(request);
     expect(parsed.ok).toBe(false);
   });
 });
@@ -49,15 +68,15 @@ describe("sanitizeDownloadFilename", () => {
 });
 
 describe("getCachedMacroReport", () => {
-  it("dedupes concurrent in-flight fetches per variant", async () => {
+  it("dedupes concurrent in-flight fetches per report kind", async () => {
     let resolve!: (value: { ok: true }) => void;
     const fetcher = async () =>
       await new Promise<{ ok: true }>((res) => {
         resolve = res;
       });
 
-    const p1 = getCachedMacroReport("variant-concurrent", fetcher);
-    const p2 = getCachedMacroReport("variant-concurrent", fetcher);
+    const p1 = getCachedMacroReport("report-concurrent", fetcher);
+    const p2 = getCachedMacroReport("report-concurrent", fetcher);
 
     expect(resolve).toBeTypeOf("function");
     resolve({ ok: true });
@@ -68,15 +87,15 @@ describe("getCachedMacroReport", () => {
   });
 
   it("retries after a failed in-flight fetch", async () => {
-    const variant = "variant-failure-then-success";
+    const reportKind = "report-failure-then-success";
 
     await expect(
-      getCachedMacroReport(variant, async () => {
+      getCachedMacroReport(reportKind, async () => {
         throw new Error("boom");
       })
     ).rejects.toThrow("boom");
 
-    const next = await getCachedMacroReport(variant, async () => ({
+    const next = await getCachedMacroReport(reportKind, async () => ({
       ok: true,
     }));
     expect(next).toEqual({ ok: true });
@@ -86,25 +105,25 @@ describe("getCachedMacroReport", () => {
     vi.useFakeTimers();
 
     try {
-      const variant = "variant-ttl";
+      const reportKind = "report-ttl";
 
       vi.setSystemTime(new Date("2026-02-05T00:00:00.000Z"));
       const fetcher1 = vi.fn(async () => ({ n: 1 }));
-      const v1 = await getCachedMacroReport(variant, fetcher1);
+      const v1 = await getCachedMacroReport(reportKind, fetcher1);
       expect(v1).toEqual({ n: 1 });
       expect(fetcher1).toHaveBeenCalledTimes(1);
 
       // Within the 1-hour TTL in `_shared.ts`, should be served from cache.
       vi.setSystemTime(new Date("2026-02-05T00:30:00.000Z"));
       const fetcher2 = vi.fn(async () => ({ n: 2 }));
-      const v2 = await getCachedMacroReport(variant, fetcher2);
+      const v2 = await getCachedMacroReport(reportKind, fetcher2);
       expect(v2).toEqual({ n: 1 });
       expect(fetcher2).toHaveBeenCalledTimes(0);
 
       // Beyond TTL, should refetch.
       vi.setSystemTime(new Date("2026-02-05T02:00:00.000Z"));
       const fetcher3 = vi.fn(async () => ({ n: 3 }));
-      const v3 = await getCachedMacroReport(variant, fetcher3);
+      const v3 = await getCachedMacroReport(reportKind, fetcher3);
       expect(v3).toEqual({ n: 3 });
       expect(fetcher3).toHaveBeenCalledTimes(1);
     } finally {

--- a/app/api/macro/_shared.ts
+++ b/app/api/macro/_shared.ts
@@ -1,27 +1,36 @@
-import { DEFAULT_DAILY_MACRO_REPORT_VARIANT_CODE } from "@/lib/messyVirgoApiClient";
+import {
+  DEFAULT_MACRO_REPORT_KIND,
+  isMacroReportKind,
+  type MacroReportKind,
+} from "@/app/lib/macro-report-kind";
 
-const VARIANT_RE = /^[a-zA-Z0-9_-]{1,64}$/;
-
-export function parseVariant(
+export function parseReportKind(
   request: Request
-): { ok: true; variant: string } | { ok: false; error: string } {
+): { ok: true; reportKind: MacroReportKind } | { ok: false; error: string } {
   const url = new URL(request.url);
-  const raw = url.searchParams.get("variant");
-  const trimmed = raw?.trim() ?? "";
-
-  if (!trimmed) {
-    return { ok: true, variant: DEFAULT_DAILY_MACRO_REPORT_VARIANT_CODE };
-  }
-
-  if (!VARIANT_RE.test(trimmed)) {
+  const legacyVariant = url.searchParams.get("variant");
+  if (legacyVariant !== null) {
     return {
       ok: false,
-      error:
-        "Invalid variant. Expected 1-64 characters: letters, numbers, '_' or '-'.",
+      error: "Invalid query parameter. Use 'report' instead of 'variant'.",
     };
   }
 
-  return { ok: true, variant: trimmed };
+  const raw = url.searchParams.get("report");
+  const trimmed = raw?.trim() ?? "";
+
+  if (!trimmed) {
+    return { ok: true, reportKind: DEFAULT_MACRO_REPORT_KIND };
+  }
+
+  if (isMacroReportKind(trimmed)) {
+    return { ok: true, reportKind: trimmed };
+  }
+
+  return {
+    ok: false,
+    error: "Invalid report. Expected 'daily' or 'default'.",
+  };
 }
 
 type CacheEntry<V> = { value: V; cachedAtMs: number };
@@ -94,26 +103,26 @@ const reportCache = createBoundedTtlCache<string, unknown>({
   ttlMs: CACHE_TTL_MS,
   maxEntries: MAX_ENTRIES,
 });
-const inFlightByVariant = new Map<string, Promise<unknown>>();
+const inFlightByReportKind = new Map<string, Promise<unknown>>();
 
-export async function getCachedMacroReport<V>(
-  variant: string,
-  fetcher: (variant: string) => Promise<V>
+export async function getCachedMacroReport<K extends string, V>(
+  reportKind: K,
+  fetcher: (reportKind: K) => Promise<V>
 ): Promise<V> {
-  const fresh = reportCache.getFresh(variant) as V | null;
+  const fresh = reportCache.getFresh(reportKind) as V | null;
   if (fresh) return fresh;
 
-  let inFlight = inFlightByVariant.get(variant) ?? null;
+  let inFlight = inFlightByReportKind.get(reportKind) ?? null;
   if (!inFlight) {
-    inFlight = fetcher(variant)
+    inFlight = fetcher(reportKind)
       .then((report) => {
-        reportCache.set(variant, report);
+        reportCache.set(reportKind, report);
         return report;
       })
       .finally(() => {
-        inFlightByVariant.delete(variant);
+        inFlightByReportKind.delete(reportKind);
       });
-    inFlightByVariant.set(variant, inFlight);
+    inFlightByReportKind.set(reportKind, inFlight);
   }
 
   return (await inFlight) as V;
@@ -123,26 +132,26 @@ const twitterPostTextCache = createBoundedTtlCache<string, unknown>({
   ttlMs: CACHE_TTL_MS,
   maxEntries: MAX_ENTRIES,
 });
-const inFlightTwitterPostByVariant = new Map<string, Promise<unknown>>();
+const inFlightTwitterPostByReportKind = new Map<string, Promise<unknown>>();
 
-export async function getCachedMacroTwitterPostText<V>(
-  variant: string,
-  fetcher: (variant: string) => Promise<V>
+export async function getCachedMacroTwitterPostText<K extends string, V>(
+  reportKind: K,
+  fetcher: (reportKind: K) => Promise<V>
 ): Promise<V> {
-  const fresh = twitterPostTextCache.getFresh(variant) as V | null;
+  const fresh = twitterPostTextCache.getFresh(reportKind) as V | null;
   if (fresh) return fresh;
 
-  let inFlight = inFlightTwitterPostByVariant.get(variant) ?? null;
+  let inFlight = inFlightTwitterPostByReportKind.get(reportKind) ?? null;
   if (!inFlight) {
-    inFlight = fetcher(variant)
+    inFlight = fetcher(reportKind)
       .then((text) => {
-        twitterPostTextCache.set(variant, text);
+        twitterPostTextCache.set(reportKind, text);
         return text;
       })
       .finally(() => {
-        inFlightTwitterPostByVariant.delete(variant);
+        inFlightTwitterPostByReportKind.delete(reportKind);
       });
-    inFlightTwitterPostByVariant.set(variant, inFlight);
+    inFlightTwitterPostByReportKind.set(reportKind, inFlight);
   }
 
   return (await inFlight) as V;

--- a/app/api/macro/download/route.test.ts
+++ b/app/api/macro/download/route.test.ts
@@ -36,7 +36,7 @@ describe("GET /api/macro/download", () => {
 
     const { GET } = await import("./route");
     const res = await GET(
-      new Request("https://example.com/api/macro/download?variant=base_app", {
+      new Request("https://example.com/api/macro/download?report=daily", {
         method: "GET",
       })
     );

--- a/app/api/macro/download/route.ts
+++ b/app/api/macro/download/route.ts
@@ -10,9 +10,10 @@ import type {
 } from "@/app/lib/report-types";
 import {
   getCachedMacroReport,
-  parseVariant,
+  parseReportKind,
   sanitizeDownloadFilename,
 } from "@/app/api/macro/_shared";
+import type { MacroReportKind } from "@/app/lib/macro-report-kind";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -26,7 +27,7 @@ function formatDateForFilename(date: Date): string {
 
 function generateFilename(
   report: PublishedMacroReportResponse,
-  variant: string
+  reportKind: MacroReportKind
 ): string {
   // Try to get date from published_at in meta
   let date = new Date();
@@ -39,18 +40,19 @@ function generateFilename(
 
   const dateStr = formatDateForFilename(date);
 
-  // Use different filename patterns based on variant
-  if (variant === "default") {
+  if (reportKind === "default") {
     return `messy-macros-report-${dateStr}.md`;
   }
 
-  // Default to market vibe daily for "base_app" and other variants
   return `messy-market-vibe-daily-${dateStr}.md`;
 }
 
-function replaceH1InHeader(header: string, variant: string): string {
+function replaceH1InHeader(
+  header: string,
+  reportKind: MacroReportKind
+): string {
   const replacementTitle =
-    variant === "default"
+    reportKind === "default"
       ? "Macros Report by $MESSY"
       : "Market Vibes Daily by $MESSY";
 
@@ -60,7 +62,7 @@ function replaceH1InHeader(header: string, variant: string): string {
 
 function extractMarkdownContent(
   report: PublishedMacroReportResponse,
-  variant: string
+  reportKind: MacroReportKind
 ): string {
   const markdownArtifact = getReportMarkdownArtifact(report.outputs);
   if (!markdownArtifact) {
@@ -81,7 +83,7 @@ function extractMarkdownContent(
     if (typeof structured.header === "string" && structured.header.trim()) {
       const processedHeader = replaceH1InHeader(
         structured.header.trim(),
-        variant
+        reportKind
       );
       parts.push(processedHeader);
     }
@@ -105,7 +107,7 @@ function extractMarkdownContent(
   const markdownText = getMarkdownReportText(report.outputs);
   if (markdownText) {
     // For unstructured content, replace H1 in the entire text
-    return replaceH1InHeader(markdownText, variant);
+    return replaceH1InHeader(markdownText, reportKind);
   }
 
   throw new Error("No markdown content found in report");
@@ -113,17 +115,17 @@ function extractMarkdownContent(
 
 export async function GET(request: Request) {
   try {
-    const parsed = parseVariant(request);
+    const parsed = parseReportKind(request);
     if (!parsed.ok) {
       return NextResponse.json({ error: parsed.error }, { status: 400 });
     }
 
-    const report = await getCachedMacroReport(parsed.variant, (variant) =>
-      getLatestDailyMacroReport(variant)
+    const report = await getCachedMacroReport(parsed.reportKind, (reportKind) =>
+      getLatestDailyMacroReport(reportKind)
     );
-    const markdownContent = extractMarkdownContent(report, parsed.variant);
+    const markdownContent = extractMarkdownContent(report, parsed.reportKind);
     const filename = sanitizeDownloadFilename(
-      generateFilename(report, parsed.variant)
+      generateFilename(report, parsed.reportKind)
     );
 
     return new NextResponse(markdownContent, {

--- a/app/api/macro/latest/route.test.ts
+++ b/app/api/macro/latest/route.test.ts
@@ -14,10 +14,10 @@ describe("GET /api/macro/latest", () => {
     vi.clearAllMocks();
   });
 
-  it("returns 400 when variant is invalid", async () => {
+  it("returns 400 when report kind is unsupported", async () => {
     const { GET } = await import("./route");
     const res = await GET(
-      new Request("https://example.com/api/macro/latest?variant=bad%0Avalue", {
+      new Request("https://example.com/api/macro/latest?report=base_app", {
         method: "GET",
       })
     );
@@ -33,6 +33,26 @@ describe("GET /api/macro/latest", () => {
     );
   });
 
+  it("fetches the requested full report kind", async () => {
+    vi.mocked(getLatestDailyMacroReport).mockResolvedValueOnce({
+      outputs: [],
+      meta: {
+        published_at: "2026-02-05T12:34:56.000Z",
+        is_stale: false,
+      },
+    });
+
+    const { GET } = await import("./route");
+    const res = await GET(
+      new Request("https://example.com/api/macro/latest?report=default", {
+        method: "GET",
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(getLatestDailyMacroReport).toHaveBeenCalledWith("default");
+  });
+
   it("returns 502 when upstream fetch fails", async () => {
     vi.mocked(getLatestDailyMacroReport).mockRejectedValueOnce(
       new Error("upstream down")
@@ -40,7 +60,7 @@ describe("GET /api/macro/latest", () => {
 
     const { GET } = await import("./route");
     const res = await GET(
-      new Request("https://example.com/api/macro/latest?variant=base_app", {
+      new Request("https://example.com/api/macro/latest?report=daily", {
         method: "GET",
       })
     );

--- a/app/api/macro/latest/route.ts
+++ b/app/api/macro/latest/route.ts
@@ -1,19 +1,19 @@
 import { NextResponse } from "next/server";
 import { getLatestDailyMacroReport } from "@/lib/messyVirgoApiClient";
-import { getCachedMacroReport, parseVariant } from "@/app/api/macro/_shared";
+import { getCachedMacroReport, parseReportKind } from "@/app/api/macro/_shared";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET(request: Request) {
   try {
-    const parsed = parseVariant(request);
+    const parsed = parseReportKind(request);
     if (!parsed.ok) {
       return NextResponse.json({ error: parsed.error }, { status: 400 });
     }
 
-    const report = await getCachedMacroReport(parsed.variant, (variant) =>
-      getLatestDailyMacroReport(variant)
+    const report = await getCachedMacroReport(parsed.reportKind, (reportKind) =>
+      getLatestDailyMacroReport(reportKind)
     );
     return NextResponse.json(report, {
       headers: {

--- a/app/api/macro/messyVirgoApiClient.test.ts
+++ b/app/api/macro/messyVirgoApiClient.test.ts
@@ -14,15 +14,28 @@ describe("Messy Virgo upstream API client", () => {
     vi.restoreAllMocks();
   });
 
-  it("fetches macro reports from the canonical public route", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      Response.json(reportResponse)
-    );
+  it("fetches the daily dashboard report from the canonical public route", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json(reportResponse));
 
-    await getLatestDailyMacroReport("base_app");
+    await getLatestDailyMacroReport("daily");
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.messyvirgo.com/api/v1/public/reports/macro/report/base_app",
+      "https://api.messyvirgo.com/api/v1/public/reports/macro/report/daily",
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+
+  it("fetches the full report from the canonical public route", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json(reportResponse));
+
+    await getLatestDailyMacroReport("default");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.messyvirgo.com/api/v1/public/reports/macro/report/default",
       expect.objectContaining({ method: "GET" })
     );
   });
@@ -39,10 +52,10 @@ describe("Messy Virgo upstream API client", () => {
       })
     );
 
-    await getLatestDailyMacroTwitterPostText("base_app");
+    await getLatestDailyMacroTwitterPostText("daily");
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.messyvirgo.com/api/v1/public/reports/macro/twitter_post/base_app",
+      "https://api.messyvirgo.com/api/v1/public/reports/macro/twitter_post/daily",
       expect.objectContaining({ method: "GET" })
     );
   });

--- a/app/api/macro/twitter-post/latest/route.ts
+++ b/app/api/macro/twitter-post/latest/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { getLatestDailyMacroTwitterPostText } from "@/lib/messyVirgoApiClient";
 import {
   getCachedMacroTwitterPostText,
-  parseVariant,
+  parseReportKind,
   sanitizeTwitterPostText,
 } from "@/app/api/macro/_shared";
 
@@ -11,14 +11,14 @@ export const runtime = "nodejs";
 
 export async function GET(request: Request) {
   try {
-    const parsed = parseVariant(request);
+    const parsed = parseReportKind(request);
     if (!parsed.ok) {
       return NextResponse.json({ error: parsed.error }, { status: 400 });
     }
 
     const text = await getCachedMacroTwitterPostText(
-      parsed.variant,
-      (variant) => getLatestDailyMacroTwitterPostText(variant)
+      parsed.reportKind,
+      (reportKind) => getLatestDailyMacroTwitterPostText(reportKind)
     );
 
     return NextResponse.json(

--- a/app/components/SidebarNav.tsx
+++ b/app/components/SidebarNav.tsx
@@ -20,6 +20,7 @@ import {
 import { cn } from "@/app/lib/utils";
 import type { PublishedMacroReportResponse } from "@/app/lib/report-types";
 import { useMacroTwitterPost } from "@/app/lib/useMacroTwitterPost";
+import type { MacroReportKind } from "@/app/lib/macro-report-kind";
 
 const NAV_ITEMS: Array<{ href: string; label: string }> = [
   { href: "/", label: "Dashboard" },
@@ -57,7 +58,7 @@ const THEME_OPTIONS = [
 
 const MACRO_REPORT_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 const TWITTER_POST_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
-const TWITTER_POST_CACHE_KEY = "mv_macro_twitter_post_base_app_cache_v1";
+const TWITTER_POST_CACHE_KEY = "mv_macro_twitter_post_daily_cache_v1";
 
 function formatReportDate(input: string | null): string {
   if (!input) return "today";
@@ -82,7 +83,7 @@ function getPublishedAtFromCachedReport(
 
 type ReportContext = {
   path: string;
-  variant: string;
+  reportKind: MacroReportKind;
   cacheKey: string;
   shareTitle: string;
 };
@@ -90,13 +91,13 @@ type ReportContext = {
 const REPORT_CONTEXT_BY_PATH: Record<string, ReportContext> = {
   "/": {
     path: "/",
-    variant: "base_app",
+    reportKind: "daily",
     cacheKey: "mv_macro_latest_cache_v1",
     shareTitle: "Market Vibe Daily",
   },
   "/full-report": {
     path: "/full-report",
-    variant: "default",
+    reportKind: "default",
     cacheKey: "mv_macro_default_cache_v1",
     shareTitle: "Full market report",
   },
@@ -147,13 +148,11 @@ export function SidebarNav() {
   const reportContext = REPORT_CONTEXT_BY_PATH[activePath] ?? null;
   const showShare = reportContext !== null;
   const showDownload = showShare;
-  const reportVariant = reportContext?.variant ?? null;
 
-  // Always pull the published share text from the upstream macro twitter_post endpoint.
-  // We keep the API variant configurable, but currently always use base_app.
+  // Always pull the published share text for the daily dashboard.
   const { text: twitterPostText } = useMacroTwitterPost({
     enabled: mounted,
-    variantCode: "base_app",
+    reportKind: "daily",
     cacheKey: TWITTER_POST_CACHE_KEY,
     ttlMs: TWITTER_POST_CACHE_TTL_MS,
   });
@@ -247,12 +246,7 @@ export function SidebarNav() {
     setIsDownloading(true);
     try {
       const url = new URL("/api/macro/download", window.location.origin);
-      // Always pass variant explicitly to ensure correct filename generation
-      const variantToUse =
-        typeof reportVariant === "string" && reportVariant.trim()
-          ? reportVariant.trim()
-          : "base_app"; // fallback to default
-      url.searchParams.set("variant", variantToUse);
+      url.searchParams.set("report", reportContext?.reportKind ?? "daily");
       // Use a direct navigation download so the browser honors Content-Disposition.
       // This is more reliable than blob downloads in embedded webviews.
       const anchor = document.createElement("a");
@@ -268,7 +262,7 @@ export function SidebarNav() {
       // We can't reliably detect when the download finishes; clear UI quickly.
       window.setTimeout(() => setIsDownloading(false), 600);
     }
-  }, [reportVariant]);
+  }, [reportContext?.reportKind]);
 
   useEffect(() => {
     setMounted(true);

--- a/app/components/macro/MacroReportRenderer.tsx
+++ b/app/components/macro/MacroReportRenderer.tsx
@@ -17,9 +17,8 @@ import {
   getReportMarkdownArtifact,
 } from "@/app/lib/lens-outputs";
 import type { LensOutputArtifact } from "@/app/lib/report-types";
+import type { MacroReportKind } from "@/app/lib/macro-report-kind";
 import { Alert, AlertDescription, AlertTitle } from "@/app/components/ui/alert";
-
-const DEFAULT_VARIANT_CODE = "base_app";
 
 const PROSE_CLASSNAME =
   "prose max-w-none text-sm leading-6 dark:prose-invert prose-headings:font-semibold prose-headings:text-foreground prose-p:text-foreground prose-strong:text-foreground prose-code:text-foreground prose-code:bg-muted prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-pre:bg-muted prose-pre:text-foreground prose-table:border prose-table:border-collapse prose-table:border-white/15 prose-th:border prose-th:border-white/15 prose-th:bg-white/5 prose-th:p-2 prose-th:text-left prose-th:font-semibold prose-td:border prose-td:border-white/15 prose-td:p-2 prose-td:text-left prose-ul:text-foreground prose-ol:text-foreground prose-li:text-foreground";
@@ -62,18 +61,10 @@ function removeHeaderSection(markdown: string): string {
 
 export function MacroReportRenderer({
   outputs,
-  variantCode,
-  macroProfileShortLabel,
-  macroCadence,
-  onMacroCadenceChange,
-  macroCadenceDisabled,
+  reportKind,
 }: {
   outputs: LensOutputArtifact[];
-  variantCode: string | null;
-  macroProfileShortLabel?: string | null;
-  macroCadence?: "daily" | "weekly";
-  onMacroCadenceChange?: (cadence: "daily" | "weekly") => void;
-  macroCadenceDisabled?: boolean;
+  reportKind: MacroReportKind;
 }) {
   const markdownArtifact = getReportMarkdownArtifact(outputs);
   const markdownContent = getMarkdownReportText(outputs);
@@ -122,17 +113,13 @@ export function MacroReportRenderer({
   }, [markdownArtifact, markdownContent]);
 
   const [isDownloading, setIsDownloading] = useState(false);
-  const showMobileDownloadAlert = variantCode?.trim() === "default";
+  const showMobileDownloadAlert = reportKind === "default";
 
   const handleDownload = useCallback(async () => {
     setIsDownloading(true);
     try {
       const url = new URL("/api/macro/download", window.location.origin);
-      const variantToUse =
-        typeof variantCode === "string" && variantCode.trim()
-          ? variantCode.trim()
-          : DEFAULT_VARIANT_CODE;
-      url.searchParams.set("variant", variantToUse);
+      url.searchParams.set("report", reportKind);
       const anchor = document.createElement("a");
       anchor.href = url.toString();
       anchor.rel = "noreferrer";
@@ -144,7 +131,7 @@ export function MacroReportRenderer({
     } finally {
       window.setTimeout(() => setIsDownloading(false), 600);
     }
-  }, [variantCode]);
+  }, [reportKind]);
 
   if (!markdownContent || !markdownArtifact) {
     return (
@@ -191,7 +178,6 @@ export function MacroReportRenderer({
           <>
             <div className="-mt-4 md:mt-8">
               <MacroReportHeaderCard
-                variantCode={variantCode}
                 executedAt={executedAt}
                 regimeLabel={regimeLabel}
                 regimeImgSrc={regimeImgSrc}
@@ -208,10 +194,6 @@ export function MacroReportRenderer({
                 adjNote={adjNote}
                 effectiveNote={effectiveNote}
                 verdictTitle={verdictTitle}
-                macroCadence={macroCadence}
-                onMacroCadenceChange={onMacroCadenceChange}
-                macroCadenceDisabled={macroCadenceDisabled}
-                macroProfileShortLabel={macroProfileShortLabel ?? null}
               />
             </div>
 

--- a/app/components/report/MacroReportHeaderCard.tsx
+++ b/app/components/report/MacroReportHeaderCard.tsx
@@ -1,12 +1,10 @@
 import Image from "next/image";
-import { ChevronLeft, ChevronRight, ExternalLink } from "lucide-react";
 import { ScoreRangeBar } from "@/app/components/ScoreRangeBar";
 import { SignedRangeBar } from "@/app/components/SignedRangeBar";
-import { cn, imageUrl } from "@/app/lib/utils";
+import { cn } from "@/app/lib/utils";
 import { formatTimestamp } from "@/app/lib/format";
 
 export function MacroReportHeaderCard(props: {
-  variantCode: string | null;
   executedAt: string | null;
   regimeLabel: string | null;
   regimeImgSrc: string;
@@ -18,18 +16,8 @@ export function MacroReportHeaderCard(props: {
   /** Shown under the effective score bar (e.g. "60.00 / 100"). */
   effectiveNote?: string;
   verdictTitle: string;
-  macroCadence?: "daily" | "weekly";
-  onMacroCadenceChange?: (cadence: "daily" | "weekly") => void;
-  macroCadenceDisabled?: boolean;
-  macroProfileShortLabel?: string | null;
-  fullReportHref?: string | null;
-  onOpenFullReport?: () => void;
-  onBackToBriefing?: () => void;
 }) {
   const {
-    macroCadence,
-    onMacroCadenceChange,
-    macroCadenceDisabled = false,
     regimeLabel,
     regimeImgSrc,
     baseScore,
@@ -40,135 +28,17 @@ export function MacroReportHeaderCard(props: {
     effectiveNote,
     verdictTitle,
     executedAt,
-    variantCode,
-    macroProfileShortLabel: _macroProfileShortLabel,
-    fullReportHref,
-    onOpenFullReport,
-    onBackToBriefing,
   } = props;
-
-  const showCadenceToggle =
-    typeof macroCadence === "string" &&
-    typeof onMacroCadenceChange === "function";
-  const isLandingPage = showCadenceToggle;
-
-  const inferredCadence =
-    macroCadence ??
-    ((variantCode ?? "").toLowerCase().includes("weekly") ? "weekly" : "daily");
 
   const dateSubtitle = (() => {
     if (!executedAt) return "";
-    if (!isLandingPage) return `as of ${formatTimestamp(executedAt)}`;
-
-    const date = new Date(executedAt);
-    if (inferredCadence === "daily") {
-      return `for ${date.toLocaleDateString(undefined, {
-        weekday: "long",
-        month: "long",
-        day: "numeric",
-        year: "numeric",
-      })}`;
-    }
-
-    const base = new Date(date);
-    const dayOfWeek = base.getDay();
-    const diff = base.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1);
-    const mondayDate = new Date(base);
-    mondayDate.setDate(diff);
-    const sundayDate = new Date(mondayDate);
-    sundayDate.setDate(sundayDate.getDate() + 6);
-    const startStr = mondayDate.toLocaleDateString(undefined, {
-      month: "long",
-      day: "numeric",
-    });
-    const endStr = sundayDate.toLocaleDateString(undefined, {
-      month: "long",
-      day: "numeric",
-      year: "numeric",
-    });
-    return `${startStr} - ${endStr}`;
+    return `as of ${formatTimestamp(executedAt)}`;
   })();
 
   return (
     <div>
       <div className="pb-9">
         <div className="space-y-8 -mt-6">
-          {showCadenceToggle && (
-            <div className="flex items-center justify-center gap-2 sm:gap-4 -mt-2">
-              <button
-                type="button"
-                onClick={() => onMacroCadenceChange?.("daily")}
-                disabled={macroCadenceDisabled}
-                className={cn(
-                  "inline-flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-full border border-white/20 text-muted-foreground hover:text-foreground hover:border-pink-400 hover:bg-pink-400/10 transition-all duration-200 flex-shrink-0",
-                  macroCadenceDisabled && "opacity-50 pointer-events-none"
-                )}
-                aria-label="Daily report"
-              >
-                <ChevronLeft className="w-4 h-4 sm:w-5 sm:h-5" />
-              </button>
-
-              <button
-                type="button"
-                onClick={() => onMacroCadenceChange?.("daily")}
-                disabled={macroCadenceDisabled}
-                className={cn(
-                  "relative w-12 h-12 sm:w-14 sm:h-14 rounded-full overflow-hidden border-2 transition-all duration-200 flex-shrink-0",
-                  macroCadence === "daily"
-                    ? "border-pink-400 ring-2 ring-pink-400/50 shadow-lg shadow-pink-400/20 scale-105"
-                    : "border-white/20 hover:border-pink-300 opacity-70 hover:opacity-100",
-                  macroCadenceDisabled && "opacity-50 pointer-events-none"
-                )}
-                aria-label="Daily report"
-                aria-pressed={macroCadence === "daily"}
-              >
-                <Image
-                  src={imageUrl("/icons/daily-icon.png")}
-                  alt="Daily"
-                  fill
-                  sizes="56px"
-                  className="object-cover"
-                />
-              </button>
-
-              <button
-                type="button"
-                onClick={() => onMacroCadenceChange?.("weekly")}
-                disabled={macroCadenceDisabled}
-                className={cn(
-                  "relative w-12 h-12 sm:w-14 sm:h-14 rounded-full overflow-hidden border-2 transition-all duration-200 flex-shrink-0",
-                  macroCadence === "weekly"
-                    ? "border-pink-400 ring-2 ring-pink-400/50 shadow-lg shadow-pink-400/20 scale-105"
-                    : "border-white/20 hover:border-pink-300 opacity-70 hover:opacity-100",
-                  macroCadenceDisabled && "opacity-50 pointer-events-none"
-                )}
-                aria-label="Weekly report"
-                aria-pressed={macroCadence === "weekly"}
-              >
-                <Image
-                  src={imageUrl("/icons/weekly-icon.png")}
-                  alt="Weekly"
-                  fill
-                  sizes="56px"
-                  className="object-cover"
-                />
-              </button>
-
-              <button
-                type="button"
-                onClick={() => onMacroCadenceChange?.("weekly")}
-                disabled={macroCadenceDisabled}
-                className={cn(
-                  "inline-flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-full border border-white/20 text-muted-foreground hover:text-foreground hover:border-pink-400 hover:bg-pink-400/10 transition-all duration-200 flex-shrink-0",
-                  macroCadenceDisabled && "opacity-50 pointer-events-none"
-                )}
-                aria-label="Weekly report"
-              >
-                <ChevronRight className="w-4 h-4 sm:w-5 sm:h-5" />
-              </button>
-            </div>
-          )}
-
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-12 items-stretch">
             <div className="flex justify-center order-1 md:order-0">
               <div
@@ -199,40 +69,6 @@ export function MacroReportHeaderCard(props: {
                 {dateSubtitle && (
                   <p className="text-sm md:text-base text-muted-foreground leading-relaxed">
                     {dateSubtitle}
-                    {isLandingPage && fullReportHref && onOpenFullReport && (
-                      <>
-                        {" • "}
-                        <button
-                          type="button"
-                          className={cn(
-                            "inline-flex items-center gap-1 text-sm md:text-base",
-                            "text-pink-300/80 hover:text-pink-200 underline underline-offset-4",
-                            "decoration-pink-400/30 hover:decoration-pink-300/60 transition-colors"
-                          )}
-                          onClick={onOpenFullReport}
-                        >
-                          <ExternalLink className="h-3 w-3" />
-                          Full Report
-                        </button>
-                      </>
-                    )}
-                    {!isLandingPage && onBackToBriefing && (
-                      <>
-                        {" • "}
-                        <button
-                          type="button"
-                          className={cn(
-                            "inline-flex items-center gap-1 text-sm md:text-base",
-                            "text-pink-300/80 hover:text-pink-200 underline underline-offset-4",
-                            "decoration-pink-400/30 hover:decoration-pink-300/60 transition-colors"
-                          )}
-                          onClick={onBackToBriefing}
-                        >
-                          <ExternalLink className="h-3 w-3" />
-                          Back to briefing
-                        </button>
-                      </>
-                    )}
                   </p>
                 )}
               </div>

--- a/app/full-report/page.tsx
+++ b/app/full-report/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMemo } from "react";
 import { PageShell } from "@/app/components/PageShell";
 import { ErrorDisplay } from "@/app/components/ErrorDisplay";
 import { MacroReportRenderer } from "@/app/components/macro/MacroReportRenderer";
@@ -15,7 +14,7 @@ import {
 
 const MACRO_REPORT_CACHE_KEY = "mv_macro_default_cache_v1";
 const MACRO_REPORT_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
-const REPORT_VARIANT_CODE = "default";
+const REPORT_KIND = "default";
 
 export default function FullReportPage() {
   const {
@@ -27,14 +26,13 @@ export default function FullReportPage() {
     acknowledge,
   } = useLegalAcknowledgement();
 
-  const reportVariantCode = useMemo(() => REPORT_VARIANT_CODE, []);
   const {
     status: macroStatus,
     error: macroError,
     report: macroReport,
   } = useMacroReport({
     enabled: mounted,
-    variantCode: reportVariantCode,
+    reportKind: REPORT_KIND,
     cacheKey: MACRO_REPORT_CACHE_KEY,
     ttlMs: MACRO_REPORT_CACHE_TTL_MS,
   });
@@ -64,10 +62,7 @@ export default function FullReportPage() {
       {isGateOpen && macroStatus === "success" && macroReport?.outputs && (
         <MacroReportRenderer
           outputs={macroReport.outputs}
-          variantCode={reportVariantCode}
-          macroProfileShortLabel={null}
-          macroCadence="daily"
-          macroCadenceDisabled={true}
+          reportKind={REPORT_KIND}
         />
       )}
 

--- a/app/lib/macro-report-kind.ts
+++ b/app/lib/macro-report-kind.ts
@@ -1,0 +1,7 @@
+export type MacroReportKind = "daily" | "default";
+
+export const DEFAULT_MACRO_REPORT_KIND: MacroReportKind = "daily";
+
+export function isMacroReportKind(value: string): value is MacroReportKind {
+  return value === "daily" || value === "default";
+}

--- a/app/lib/useMacroReport.ts
+++ b/app/lib/useMacroReport.ts
@@ -2,18 +2,19 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { PublishedMacroReportResponse } from "@/app/lib/report-types";
+import type { MacroReportKind } from "@/app/lib/macro-report-kind";
 
 export type MacroReportStatus = "idle" | "loading" | "success" | "error";
 
 type CachedMacroReportEnvelope = {
   cachedAtMs?: unknown;
-  variantCode?: unknown;
+  reportKind?: unknown;
   report?: unknown;
 };
 
 type UseMacroReportOptions = {
   enabled: boolean;
-  variantCode: string;
+  reportKind: MacroReportKind;
   cacheKey: string;
   ttlMs: number;
 };
@@ -27,7 +28,7 @@ type UseMacroReportResult = {
 
 function loadCachedReport(
   cacheKey: string,
-  variantCode: string,
+  reportKind: MacroReportKind,
   ttlMs: number
 ) {
   if (typeof window === "undefined") return null;
@@ -40,8 +41,7 @@ function loadCachedReport(
     if (typeof parsed?.cachedAtMs !== "number") return null;
     if (!parsed.report) return null;
 
-    // Validate that cached variant matches current variant
-    if (parsed.variantCode !== variantCode) return null;
+    if (parsed.reportKind !== reportKind) return null;
 
     const ageMs = Date.now() - parsed.cachedAtMs;
     if (ageMs < 0 || ageMs > ttlMs) return null;
@@ -54,7 +54,7 @@ function loadCachedReport(
 
 function persistCachedReport(
   cacheKey: string,
-  variantCode: string,
+  reportKind: MacroReportKind,
   report: PublishedMacroReportResponse
 ) {
   if (typeof window === "undefined") return;
@@ -64,7 +64,7 @@ function persistCachedReport(
       cacheKey,
       JSON.stringify({
         cachedAtMs: Date.now(),
-        variantCode,
+        reportKind,
         report,
       })
     );
@@ -75,7 +75,7 @@ function persistCachedReport(
 
 export function useMacroReport({
   enabled,
-  variantCode,
+  reportKind,
   cacheKey,
   ttlMs,
 }: UseMacroReportOptions): UseMacroReportResult {
@@ -100,7 +100,7 @@ export function useMacroReport({
 
     try {
       const url = new URL("/api/macro/latest", window.location.origin);
-      url.searchParams.set("variant", variantCode);
+      url.searchParams.set("report", reportKind);
 
       const response = await fetch(url.toString(), {
         signal: controller.signal,
@@ -122,7 +122,7 @@ export function useMacroReport({
 
       setReport(nextReport);
       setStatus("success");
-      persistCachedReport(cacheKey, variantCode, nextReport);
+      persistCachedReport(cacheKey, reportKind, nextReport);
     } catch (fetchError) {
       if (
         fetchError instanceof DOMException &&
@@ -141,14 +141,13 @@ export function useMacroReport({
         abortRef.current = null;
       }
     }
-  }, [cacheKey, variantCode]);
+  }, [cacheKey, reportKind]);
 
   useEffect(() => {
     if (!enabled) return;
 
     // Prefer cache to avoid re-fetching the same daily payload.
-    // Validate variantCode matches to prevent returning stale data for wrong variant.
-    const cached = loadCachedReport(cacheKey, variantCode, ttlMs);
+    const cached = loadCachedReport(cacheKey, reportKind, ttlMs);
     if (cached) {
       setError(null);
       setReport(cached);
@@ -162,7 +161,7 @@ export function useMacroReport({
     return () => {
       abortRef.current?.abort();
     };
-  }, [cacheKey, enabled, refetch, ttlMs, variantCode]);
+  }, [cacheKey, enabled, refetch, ttlMs, reportKind]);
 
   return { status, error, report, refetch };
 }

--- a/app/lib/useMacroTwitterPost.ts
+++ b/app/lib/useMacroTwitterPost.ts
@@ -1,18 +1,19 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { MacroReportKind } from "@/app/lib/macro-report-kind";
 
 export type MacroTwitterPostStatus = "idle" | "loading" | "success" | "error";
 
 type CachedTwitterPostEnvelope = {
   cachedAtMs?: unknown;
-  variantCode?: unknown;
+  reportKind?: unknown;
   text?: unknown;
 };
 
 type UseMacroTwitterPostOptions = {
   enabled: boolean;
-  variantCode: string;
+  reportKind: MacroReportKind;
   cacheKey: string;
   ttlMs: number;
 };
@@ -24,7 +25,11 @@ type UseMacroTwitterPostResult = {
   refetch: () => Promise<void>;
 };
 
-function loadCachedText(cacheKey: string, variantCode: string, ttlMs: number) {
+function loadCachedText(
+  cacheKey: string,
+  reportKind: MacroReportKind,
+  ttlMs: number
+) {
   if (typeof window === "undefined") return null;
 
   try {
@@ -33,7 +38,7 @@ function loadCachedText(cacheKey: string, variantCode: string, ttlMs: number) {
 
     const parsed = JSON.parse(raw) as CachedTwitterPostEnvelope;
     if (typeof parsed?.cachedAtMs !== "number") return null;
-    if (parsed.variantCode !== variantCode) return null;
+    if (parsed.reportKind !== reportKind) return null;
     if (typeof parsed.text !== "string" || !parsed.text.trim()) return null;
 
     const ageMs = Date.now() - parsed.cachedAtMs;
@@ -47,7 +52,7 @@ function loadCachedText(cacheKey: string, variantCode: string, ttlMs: number) {
 
 function persistCachedText(
   cacheKey: string,
-  variantCode: string,
+  reportKind: MacroReportKind,
   text: string
 ) {
   if (typeof window === "undefined") return;
@@ -59,7 +64,7 @@ function persistCachedText(
       cacheKey,
       JSON.stringify({
         cachedAtMs: Date.now(),
-        variantCode,
+        reportKind,
         text: trimmed,
       })
     );
@@ -70,7 +75,7 @@ function persistCachedText(
 
 export function useMacroTwitterPost({
   enabled,
-  variantCode,
+  reportKind,
   cacheKey,
   ttlMs,
 }: UseMacroTwitterPostOptions): UseMacroTwitterPostResult {
@@ -96,7 +101,7 @@ export function useMacroTwitterPost({
         "/api/macro/twitter-post/latest",
         window.location.origin
       );
-      url.searchParams.set("variant", variantCode);
+      url.searchParams.set("report", reportKind);
 
       const response = await fetch(url.toString(), {
         signal: controller.signal,
@@ -128,7 +133,7 @@ export function useMacroTwitterPost({
 
       setText(nextText);
       setStatus("success");
-      persistCachedText(cacheKey, variantCode, nextText);
+      persistCachedText(cacheKey, reportKind, nextText);
     } catch (fetchError) {
       if (
         fetchError instanceof DOMException &&
@@ -147,12 +152,12 @@ export function useMacroTwitterPost({
         abortRef.current = null;
       }
     }
-  }, [cacheKey, variantCode]);
+  }, [cacheKey, reportKind]);
 
   useEffect(() => {
     if (!enabled) return;
 
-    const cached = loadCachedText(cacheKey, variantCode, ttlMs);
+    const cached = loadCachedText(cacheKey, reportKind, ttlMs);
     if (cached) {
       setError(null);
       setText(cached);
@@ -166,7 +171,7 @@ export function useMacroTwitterPost({
     return () => {
       abortRef.current?.abort();
     };
-  }, [cacheKey, enabled, refetch, ttlMs, variantCode]);
+  }, [cacheKey, enabled, refetch, ttlMs, reportKind]);
 
   return { status, error, text, refetch };
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMemo } from "react";
 import { PageShell } from "@/app/components/PageShell";
 import { ErrorDisplay } from "@/app/components/ErrorDisplay";
 import { MacroReportRenderer } from "@/app/components/macro/MacroReportRenderer";
@@ -15,6 +14,7 @@ import {
 
 const MACRO_REPORT_CACHE_KEY = "mv_macro_latest_cache_v1";
 const MACRO_REPORT_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const REPORT_KIND = "daily";
 
 export default function Home() {
   const {
@@ -26,32 +26,24 @@ export default function Home() {
     acknowledge,
   } = useLegalAcknowledgement();
 
-  const reportVariantCode = useMemo(() => "base_app", []);
   const {
     status: macroStatus,
     error: macroError,
     report: macroReport,
   } = useMacroReport({
     enabled: mounted,
-    variantCode: reportVariantCode,
+    reportKind: REPORT_KIND,
     cacheKey: MACRO_REPORT_CACHE_KEY,
     ttlMs: MACRO_REPORT_CACHE_TTL_MS,
   });
-
-  const dashboardTitle = useMemo(() => {
-    void reportVariantCode;
-    return "Market Vibe Daily";
-  }, [reportVariantCode]);
 
   const isGateOpen = mounted && hasAcknowledgedLegal;
 
   return (
     <PageShell mainClassName="gap-8">
-      {dashboardTitle && (
-        <h1 className="text-5xl font-bold font-serif text-gradient leading-[1.15] text-center -mt-4 md:mt-0">
-          {dashboardTitle}
-        </h1>
-      )}
+      <h1 className="text-5xl font-bold font-serif text-gradient leading-[1.15] text-center -mt-4 md:mt-0">
+        Market Vibe Daily
+      </h1>
 
       {!mounted && <AppBootSplash />}
 
@@ -70,10 +62,7 @@ export default function Home() {
       {isGateOpen && macroStatus === "success" && macroReport?.outputs && (
         <MacroReportRenderer
           outputs={macroReport.outputs}
-          variantCode={reportVariantCode}
-          macroProfileShortLabel={null}
-          macroCadence="daily"
-          macroCadenceDisabled={true}
+          reportKind={REPORT_KIND}
         />
       )}
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,16 +23,16 @@ Market Vibe Daily is a Base Mini App built with Next.js (App Router). It serves 
 
 1. User opens the Base Mini App (Base App webview).
 2. Legal acknowledgement gate opens on first visit.
-3. Client calls `GET /api/macro/latest?variant=base_app`.
-4. Server fetches the latest report from the Messy Virgo API and caches it.
+3. Client calls `GET /api/macro/latest?report=daily`.
+4. Server fetches the daily report from the Messy Virgo API and caches it.
 5. Client renders a daily briefing and header scores from markdown artifacts.
-6. Optional: user downloads the report via `GET /api/macro/download`.
+6. Optional: user downloads the report via `GET /api/macro/download?report=daily`.
 
 ## Entry points
 
 - **Base App URL**: `https://base.app/app/messyvirgo-base-macros.vercel.app/`
-- **Daily briefing**: `/` (variant `base_app`)
-- **Full report**: `/full-report` (variant `default`)
+- **Daily briefing**: `/` (`report=daily`)
+- **Full report**: `/full-report` (`report=default`)
 - **Manifest**: `/.well-known/farcaster.json`
 
 ## Key flows
@@ -45,17 +45,22 @@ Market Vibe Daily is a Base Mini App built with Next.js (App Router). It serves 
 
 `/api/macro/latest`:
 
-- Validates `variant` via `parseVariant(...)`.
+- Validates `report` via `parseReportKind(...)`; only `daily` and `default` are supported.
 - Fetches data from the upstream API using `getLatestDailyMacroReport(...)`.
 - Caches the response in an in-memory TTL cache (1 hour).
 - Returns `PublishedMacroReportResponse` JSON.
+
+Upstream report endpoints:
+
+- Dashboard: `GET /api/v1/public/reports/macro/report/daily`
+- Full report: `GET /api/v1/public/reports/macro/report/default`
 
 ### 3) Client caching + render
 
 `useMacroReport(...)`:
 
 - Loads cached report from `localStorage` when fresh.
-- Otherwise fetches `/api/macro/latest`.
+- Otherwise fetches `/api/macro/latest?report=<daily|default>`.
 - Passes outputs to `MacroReportRenderer`, which extracts markdown and scores.
 
 ### 4) Report download (Markdown)
@@ -64,7 +69,7 @@ Market Vibe Daily is a Base Mini App built with Next.js (App Router). It serves 
 
 - Fetches the same cached report as above.
 - Extracts markdown artifacts and assembles a single markdown file.
-- Returns a file download with a variant-specific filename.
+- Returns a file download with a report-specific filename.
 
 ### 5) Webhook receiver
 
@@ -85,7 +90,7 @@ Market Vibe Daily is a Base Mini App built with Next.js (App Router). It serves 
 
 ## Caching strategy
 
-- **Server**: bounded in-memory TTL cache (1 hour, max 50 variants).
+- **Server**: bounded in-memory TTL cache (1 hour, max 50 report entries).
 - **Client**: `localStorage` TTL cache (1 hour) to avoid repeat fetches.
 
 ## External dependencies

--- a/docs/superpowers/plans/2026-05-13-remove-user-profile-report-variants.md
+++ b/docs/superpowers/plans/2026-05-13-remove-user-profile-report-variants.md
@@ -1,0 +1,73 @@
+# Remove User Profile Report Variants Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove app-level report profile and variant selection while keeping exactly two report products: dashboard and full report.
+
+**Architecture:** Replace arbitrary report variant strings with a fixed `MacroReportKind` union of `daily` and `default`. Keep the existing local proxy shape but rename its selection parameter to `report`, defaulting to `daily`; the proxy and client reject all other values.
+
+**Tech Stack:** Next.js App Router, React, TypeScript, Vitest.
+
+---
+
+### Task 1: Lock API Behavior With Failing Tests
+
+**Files:**
+
+- Modify: `app/api/macro/messyVirgoApiClient.test.ts`
+- Modify: `app/api/macro/_shared.test.ts`
+- Modify: `app/api/macro/latest/route.test.ts`
+
+- [ ] Update the upstream client test so dashboard fetch expects `https://api.messyvirgo.com/api/v1/public/reports/macro/report/daily`.
+- [ ] Add a full report client test expecting `https://api.messyvirgo.com/api/v1/public/reports/macro/report/default`.
+- [ ] Update local API shared parser tests so missing `report` defaults to `daily`, `report=default` is accepted, and an unsupported value returns an error.
+- [ ] Update local route tests so `report=base_app` returns 400 and `report=default` calls the upstream client with `default`.
+- [ ] Run `npm run test:ci` and confirm the new expectations fail before production code changes.
+
+### Task 2: Replace Variants With Fixed Report Kinds
+
+**Files:**
+
+- Modify: `lib/messyVirgoApiClient.ts`
+- Modify: `app/api/macro/_shared.ts`
+- Modify: `app/api/macro/latest/route.ts`
+- Modify: `app/api/macro/download/route.ts`
+- Modify: `app/lib/useMacroReport.ts`
+
+- [ ] Add `export type MacroReportKind = "daily" | "default"` and `DEFAULT_MACRO_REPORT_KIND = "daily"` in `lib/messyVirgoApiClient.ts`.
+- [ ] Replace report path resolution so `getLatestDailyMacroReport("daily")` fetches `/report/daily` and `"default"` fetches `/report/default`.
+- [ ] Replace `parseVariant` with `parseReportKind`, accepting only missing, `daily`, or `default`.
+- [ ] Make cache helpers use report kind names in parameters and map keys.
+- [ ] Update `/api/macro/latest` to call `parseReportKind` and `getLatestDailyMacroReport(kind)`.
+- [ ] Update downloads and `useMacroReport` URLs to use `report=<kind>` instead of `variant=<variant>`.
+- [ ] Run the targeted API tests and confirm they pass.
+
+### Task 3: Remove Profile/Cadence UI Surface
+
+**Files:**
+
+- Modify: `app/page.tsx`
+- Modify: `app/full-report/page.tsx`
+- Modify: `app/components/macro/MacroReportRenderer.tsx`
+- Modify: `app/components/report/MacroReportHeaderCard.tsx`
+- Modify: `app/components/SidebarNav.tsx`
+
+- [ ] Set dashboard page report kind to `daily` and cache key to a daily-specific key.
+- [ ] Set full report page report kind to `default`.
+- [ ] Remove `macroProfileShortLabel`, `macroCadence`, `onMacroCadenceChange`, and `macroCadenceDisabled` props from `MacroReportRenderer`.
+- [ ] Remove cadence toggle and profile-label props from `MacroReportHeaderCard`.
+- [ ] Update sharing and download context in `SidebarNav` to use `reportKind` instead of `variant`.
+- [ ] Run TypeScript checking to catch any remaining prop references.
+
+### Task 4: Documentation And Verification
+
+**Files:**
+
+- Modify: `docs/architecture.md`
+- Modify: `README.md`
+
+- [ ] Update endpoint and report wording away from profile/variant selection.
+- [ ] Search for remaining `base_app`, `variant`, `macroProfile`, and cadence-selection references.
+- [ ] Run `npm run typecheck`.
+- [ ] Run `npm run test:ci`.
+- [ ] Run `npm run format:check`.

--- a/docs/superpowers/specs/2026-05-13-remove-user-profile-report-variants-design.md
+++ b/docs/superpowers/specs/2026-05-13-remove-user-profile-report-variants-design.md
@@ -1,0 +1,28 @@
+# Remove User Profile Report Variants Design
+
+## Goal
+
+Remove app-level report profile and variant selection so the product exposes only two report surfaces: the daily dashboard and the full report.
+
+## Scope
+
+MiniKit and Farcaster integration stays in place. The removal is limited to app report/profile selection surfaces, variant-oriented API behavior, and related UI props.
+
+## Report Products
+
+- Dashboard page `/` loads the upstream daily dashboard report from `GET /api/v1/public/reports/macro/report/daily`.
+- Full report page `/full-report` loads the upstream full report from `GET /api/v1/public/reports/macro/report/default`.
+
+## Architecture
+
+The upstream API client will use a fixed report kind union instead of arbitrary variant strings. The local Next API proxy will accept only `report=daily` or `report=default`, defaulting to `daily` for existing dashboard callers. The cache key will use report kind, not variant.
+
+Client pages will pass report kind and local storage cache keys through `useMacroReport`. Report rendering will no longer accept or forward profile labels or cadence selection props. The header card will show report data only, without profile or daily/weekly controls.
+
+## Error Handling
+
+The local proxy returns HTTP 400 for unsupported report values. Upstream failures continue returning HTTP 502 with debug detail outside production.
+
+## Testing
+
+Tests will cover upstream client URL mapping and local proxy rejection of unsupported report values. Existing cache and download tests will be updated from variant language to report kind language where the touched code requires it.

--- a/lib/messyVirgoApiClient.ts
+++ b/lib/messyVirgoApiClient.ts
@@ -2,6 +2,11 @@ import "server-only";
 
 import type { PublishedMacroReportResponse } from "@/app/lib/report-types";
 import { isPublishedMacroReportResponse } from "@/app/lib/report-guards";
+import {
+  DEFAULT_MACRO_REPORT_KIND,
+  isMacroReportKind,
+  type MacroReportKind,
+} from "@/app/lib/macro-report-kind";
 
 type ClientOptions = {
   signal?: AbortSignal;
@@ -11,28 +16,30 @@ type ClientOptions = {
 const API_BASE_URL =
   process.env.MESSY_VIRGO_API_BASE_URL ?? "https://api.messyvirgo.com";
 
-export const DEFAULT_DAILY_MACRO_REPORT_VARIANT_CODE = "base_app";
+export { DEFAULT_MACRO_REPORT_KIND };
+export type { MacroReportKind };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
-function resolveDailyMacroPath(variantCode: string): string {
+function normalizeMacroReportKind(reportKind: string): MacroReportKind {
   const normalized =
-    typeof variantCode === "string" && variantCode.trim()
-      ? variantCode.trim()
-      : DEFAULT_DAILY_MACRO_REPORT_VARIANT_CODE;
-  // Variant codes are a single path segment in the upstream API.
-  return `/api/v1/public/reports/macro/report/${encodeURIComponent(normalized)}`;
+    typeof reportKind === "string" && reportKind.trim()
+      ? reportKind.trim()
+      : DEFAULT_MACRO_REPORT_KIND;
+  if (isMacroReportKind(normalized)) return normalized;
+  return DEFAULT_MACRO_REPORT_KIND;
 }
 
-function resolveDailyMacroTwitterPostPath(variantCode: string): string {
-  const normalized =
-    typeof variantCode === "string" && variantCode.trim()
-      ? variantCode.trim()
-      : DEFAULT_DAILY_MACRO_REPORT_VARIANT_CODE;
-  // Variant codes are a single path segment in the upstream API.
-  return `/api/v1/public/reports/macro/twitter_post/${encodeURIComponent(normalized)}`;
+function resolveDailyMacroPath(reportKind: string): string {
+  const normalized = normalizeMacroReportKind(reportKind);
+  return `/api/v1/public/reports/macro/report/${normalized}`;
+}
+
+function resolveDailyMacroTwitterPostPath(reportKind: string): string {
+  const normalized = normalizeMacroReportKind(reportKind);
+  return `/api/v1/public/reports/macro/twitter_post/${normalized}`;
 }
 
 function buildAuthHeaders(): Record<string, string> {
@@ -97,10 +104,10 @@ function extractTextFromUpstreamJson(value: unknown): string | null {
 }
 
 export async function getLatestDailyMacroReport(
-  variantCode: string = DEFAULT_DAILY_MACRO_REPORT_VARIANT_CODE,
+  reportKind: MacroReportKind = DEFAULT_MACRO_REPORT_KIND,
   options?: ClientOptions
 ): Promise<PublishedMacroReportResponse> {
-  const url = new URL(resolveDailyMacroPath(variantCode), API_BASE_URL);
+  const url = new URL(resolveDailyMacroPath(reportKind), API_BASE_URL);
 
   const timeoutMs = options?.timeoutMs ?? 12_000;
   const controller = new AbortController();
@@ -149,11 +156,11 @@ export async function getLatestDailyMacroReport(
 }
 
 export async function getLatestDailyMacroTwitterPostText(
-  variantCode: string = DEFAULT_DAILY_MACRO_REPORT_VARIANT_CODE,
+  reportKind: MacroReportKind = DEFAULT_MACRO_REPORT_KIND,
   options?: ClientOptions
 ): Promise<string> {
   const url = new URL(
-    resolveDailyMacroTwitterPostPath(variantCode),
+    resolveDailyMacroTwitterPostPath(reportKind),
     API_BASE_URL
   );
 


### PR DESCRIPTION
## Summary

- Remove app-level report profile and variant selection surfaces.
- Restrict macro reports to the two supported report kinds: `daily` for the dashboard and `default` for the full report.
- Route local report, download, and twitter-post proxy calls through `report=<daily|default>` instead of arbitrary `variant` values.
- Reject stale `variant` query parameters so old links do not silently fall back to the daily report.
- Keep MiniKit/Farcaster integration intact.

## Impact

Users now see only the daily dashboard and full report. The app no longer exposes report profile/cadence selection behavior, and API callers receive a 400 for unsupported or stale report selectors.

## Validation

- `npm run test:ci -- app/api/macro/_shared.test.ts`
- `npm run typecheck`
- `npm run format:check`
- `npm run test:ci`
- `npm run lint`
- `npm run build`
- `git diff --check`